### PR TITLE
Disable interactivity for waves footer.

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,113 +1,131 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <base href="[[=URL('static')]]/" />
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link
-      rel="shortcut icon"
-      href="data:image/x-icon;base64,AAABAAEAAQEAAAEAIAAwAAAAFgAAACgAAAABAAAAAgAAAAEAIAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAAAA=="
-    />
-    <link rel="stylesheet" href="css/bulma.css" />
-    <link rel="stylesheet" href="font-awesome-4.7.0/css/font-awesome.css" />
-    [[block page_head]]
-    <!-- individual pages can customize header here -->
-    [[end]]
-  </head>
-  <body>
-    <!-- Navigation bar -->
-    <nav class="navbar is-dark" role="navigation" aria-label="main navigation">
-      <div class="navbar-brand">
-        <a class="navbar-item" href="[[=URL('index')]]">
-          WavyWork
-          <!-- <img class="logo" width="150" src="images/site_icon.png"> -->
-        </a>
-
-        <a
-          role="button"
-          class="navbar-burger burger"
-          aria-label="menu"
-          aria-expanded="false"
-          data-target="the-navbar-menu"
-          onclick="this.classList.toggle('is-active');document.getElementById(this.dataset.target).classList.toggle('is-active');"
+    <head>
+        <base href="[[=URL('static')]]/" />
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link
+            rel="shortcut icon"
+            href="data:image/x-icon;base64,AAABAAEAAQEAAAEAIAAwAAAAFgAAACgAAAABAAAAAgAAAAEAIAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAPAAAAAA=="
+        />
+        <link rel="stylesheet" href="css/bulma.css" />
+        <link rel="stylesheet" href="font-awesome-4.7.0/css/font-awesome.css" />
+        [[block page_head]]
+        <!-- individual pages can customize header here -->
+        [[end]]
+    </head>
+    <body>
+        <!-- Navigation bar -->
+        <nav
+            class="navbar is-dark"
+            role="navigation"
+            aria-label="main navigation"
         >
-          <span aria-hidden="true"></span>
-          <span aria-hidden="true"></span>
-          <span aria-hidden="true"></span>
-        </a>
-      </div>
-
-      <div id="the-navbar-menu" class="navbar-menu">
-        <div class="navbar-start">
-          [[block page_menu_items]]<!-- individual pages can add menu items here -->[[end]]
-        </div>
-
-        <div class="navbar-end">
-          <div class="navbar-item">
-            <div class="buttons">
-              [[if globals().get('user'):]]
-              <div class="navbar-item has-dropdown is-hoverable">
-                <a class="navbar-link is-primary">
-                  [[=globals().get('user').get('email')]]
+            <div class="navbar-brand">
+                <a class="navbar-item" href="[[=URL('index')]]">
+                    WavyWork
+                    <!-- <img class="logo" width="150" src="images/site_icon.png"> -->
                 </a>
-                <div class="navbar-dropdown">
-                  <a class="navbar-item" href="[[=URL('auth/logout')]]"
-                    >Logout</a
-                  >
-                  <a class="navbar-item" href="[[=URL('auth/profile')]]"
-                    >Profile</a
-                  >
-                  <a class="navbar-item" href="[[=URL('auth/change_password')]]"
-                    >Change Password</a
-                  >
-                </div>
-              </div>
-              [[else:]]
-              <a class="button is-link" href="[[=URL('auth/register')]]"
-                >Sign up</a
-              >
-              <a class="button is-success" href="[[=URL('auth/login')]]"
-                >Log in</a
-              >
-              [[pass]]
+
+                <a
+                    role="button"
+                    class="navbar-burger burger"
+                    aria-label="menu"
+                    aria-expanded="false"
+                    data-target="the-navbar-menu"
+                    onclick="this.classList.toggle('is-active');document.getElementById(this.dataset.target).classList.toggle('is-active');"
+                >
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                    <span aria-hidden="true"></span>
+                </a>
             </div>
-          </div>
-        </div>
-      </div>
-    </nav>
 
-    <!-- beginning of HTML inserted by extending template -->
-    [[include]]
+            <div id="the-navbar-menu" class="navbar-menu">
+                <div class="navbar-start">
+                    [[block page_menu_items]]<!-- individual pages can add menu items here -->[[end]]
+                </div>
 
-    <!-- Taken from https://stackoverflow.com/questions/2570877/how-do-i-stick-an-image-to-the-bottom-of-the-visible-screen-and-be-centered  -->
-    <style>
-      .sticky-image-wrapper {
-        position: fixed;
-        bottom: 0;
-        width: 100%;
-      }
+                <div class="navbar-end">
+                    <div class="navbar-item">
+                        <div class="buttons">
+                            [[if globals().get('user'):]]
+                            <div class="navbar-item has-dropdown is-hoverable">
+                                <a class="navbar-link is-primary">
+                                    [[=globals().get('user').get('email')]]
+                                </a>
+                                <div class="navbar-dropdown">
+                                    <a
+                                        class="navbar-item"
+                                        href="[[=URL('auth/logout')]]"
+                                        >Logout</a
+                                    >
+                                    <a
+                                        class="navbar-item"
+                                        href="[[=URL('auth/profile')]]"
+                                        >Profile</a
+                                    >
+                                    <a
+                                        class="navbar-item"
+                                        href="[[=URL('auth/change_password')]]"
+                                        >Change Password</a
+                                    >
+                                </div>
+                            </div>
+                            [[else:]]
+                            <a
+                                class="button is-link"
+                                href="[[=URL('auth/register')]]"
+                                >Sign up</a
+                            >
+                            <a
+                                class="button is-success"
+                                href="[[=URL('auth/login')]]"
+                                >Log in</a
+                            >
+                            [[pass]]
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </nav>
 
-      .sticky-image-wrapper img {
-        display: table;
-        position: relative;
-        margin: auto;
-      }
-    </style>
+        <!-- beginning of HTML inserted by extending template -->
+        [[include]]
 
-    <!-- end of HTML inserted by extending template -->
-    <!-- <footer class="footer">
+        <!-- Taken from https://stackoverflow.com/questions/2570877/how-do-i-stick-an-image-to-the-bottom-of-the-visible-screen-and-be-centered  -->
+        <style>
+            .sticky-image-wrapper {
+                position: fixed;
+                bottom: 0;
+                width: 100%;
+            }
+
+            .sticky-image-wrapper img {
+                display: table;
+                position: relative;
+                margin: auto;
+            }
+        </style>
+
+        <!-- end of HTML inserted by extending template -->
+        <!-- <footer class="footer">
       <div class="content has-text-centered">
         Made with <a href="https://py4web.com">py4web</a>.
         <a href="https://learn-py4web.github.io">Learn py4web!</a>
       </div>
     </footer> -->
-    <figure class="image sticky-image-wrapper">
-      <img src="images/waves.png" class="mt-auto" />
-    </figure>
-  </body>
-  <script src="js/sugar.min.js"></script>
-  <script src="js/axios.min.js"></script>
-  <script src="js/vue.js"></script>
-  <script src="js/utils.js"></script>
-  [[block page_scripts]]<!-- individual pages can add scripts here -->[[end]]
+        <figure class="image sticky-image-wrapper">
+            <img
+                src="images/waves.png"
+                class="mt-auto"
+                style="pointer-events: none"
+            />
+        </figure>
+    </body>
+    <script src="js/sugar.min.js"></script>
+    <script src="js/axios.min.js"></script>
+    <script src="js/vue.js"></script>
+    <script src="js/utils.js"></script>
+    [[block page_scripts]]<!-- individual pages can add scripts here -->[[end]]
 </html>


### PR DESCRIPTION
Before this change the footer (which is just a standard png image) could be interacted rather than appear as just background for the page. This change prevents users from accidentally dragging or opening the right-click dialog by disabling all "pointer events." The scope is minimal (only change is on line 122) but due to auto-formatting several lines were reflowed/re-spaced. 